### PR TITLE
Update lint to come from ember-test-utils

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,11 @@
+{
+  "plugins": {
+    "lint": {
+      "list-item-indent": false,
+      "maximum-line-length": 119
+    }
+  },
+  "settings": {
+    "commonmark": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ ember install ember-frost-file-picker
 | `validateDrag` | `string` | `<action-name>` | Action to trigger to determine if `isDragging` should be applied. In Chrome, you can check event.dataTransfer.items[0] for information on the item being dragged |
 
 ## Testing with ember-hook
-The file picker component is accessible using ember-hook with the top level hook name or you can access the internal components as well -
+The file picker component is accessible using ember-hook with the top level hook name or you can access
+the internal components as well -
 * Default top level hook - `$hook('file-picker')`
 * Browse button hook - `$hook('<hook-name>-button')`
 * Input field hook - `$hook('<hook-name>-input')`

--- a/addon/components/frost-file-picker.js
+++ b/addon/components/frost-file-picker.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
-const {Component, isNone, on, run} = Ember
+const {Component, RSVP, isNone, on, run} = Ember
 import layout from '../templates/components/frost-file-picker'
 import PropTypeMixin, {PropTypes} from 'ember-prop-types'
 
@@ -75,7 +75,7 @@ export default Component.extend(PropTypeMixin, {
 
     let self = this
     files.forEach((file) => {
-      new Ember.RSVP.Promise(function (resolve, reject) {
+      new RSVP.Promise(function (resolve, reject) {
         if (typeof (self.attrs['validate']) === 'function') {
           self.attrs['validate'](file).then((result) => {
             result.valid ? resolve(file) : reject(result)

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = {
     if (this.options.babel.optional.indexOf('es7.decorators') === -1) {
       this.options.babel.optional.push('es7.decorators')
     }
+    // eslint-disable-next-line no-unused-expressions
     this._super.init && this._super.init.apply(this, arguments)
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
     "build": "ember build",
     "test": "npm run lint && COVERAGE=true ember test",
     "ci-test": "ember try:one $EMBER_TRY_SCENARIO --- ember tva --push-var='false' --msg-on=$EMBER_TRY_SCENARIO",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint",
-    "eslint": "eslint *.js addon app blueprints config tests --fix",
-    "md-lint": "remark *.md",
-    "sass-lint": "sass-lint -q -v"
+    "lint": "lint-all-the-things"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-file-picker.git",
   "engines": {
@@ -58,14 +55,9 @@
     "ember-prop-types": "~3.0.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.5.1",
-    "ember-test-utils": "^1.1.2",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.2.0",
-    "eslint": "^3.4.0",
-    "eslint-config-frost-standard": "^4.0.0",
-    "loader.js": "^4.0.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.1.0",
-    "sass-lint": "^1.9.1"
+    "loader.js": "^4.0.0"
   },
   "keywords": [
     "ember-addon",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,13 +1,14 @@
-import Ember from 'ember'
-import Resolver from './resolver'
-import loadInitializers from 'ember-load-initializers'
 import config from './config/environment'
+import Ember from 'ember'
+const {Application} = Ember
+import loadInitializers from 'ember-load-initializers'
+import Resolver from './resolver'
 
 let App
 
 Ember.MODEL_FACTORY_INJECTIONS = true
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/pods/application/controller.js
+++ b/tests/dummy/app/pods/application/controller.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+const {Controller} = Ember
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 })

--- a/tests/dummy/app/pods/application/route.js
+++ b/tests/dummy/app/pods/application/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+const {Route} = Ember
 
-export default Ember.Route.extend({
+export default Route.extend({
 })

--- a/tests/dummy/app/pods/demo/controller.js
+++ b/tests/dummy/app/pods/demo/controller.js
@@ -1,13 +1,15 @@
 import Ember from 'ember'
+const {Controller, RSVP, inject} = Ember
+const {service} = inject
 
-export default Ember.Controller.extend({
-  notifications: Ember.inject.service('notification-messages'),
+export default Controller.extend({
+  notifications: service('notification-messages'),
 
   selectedTab: 'readme',
 
   actions: {
     validateFile (file) {
-      return new Ember.RSVP.Promise((resolve) => {
+      return new RSVP.Promise((resolve) => {
         if (file != null) {
           this.get('notifications').success('Selected file of type: ' + file.type, {
             autoClear: true,

--- a/tests/dummy/app/pods/demo/route.js
+++ b/tests/dummy/app/pods/demo/route.js
@@ -1,5 +1,5 @@
 import Ember from 'ember'
+const {Route} = Ember
 
-export default Ember.Route.extend({
-
+export default Route.extend({
 })

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,13 +1,14 @@
 import Ember from 'ember'
 import config from './config/environment'
+const {Router: EmberRouter} = Ember
 
-var Router = Ember.Router.extend({
+var Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 })
 
 Router.map(function () {
-  this.route('demo', { path: '/' })
+  this.route('demo', {path: '/'})
 })
 
 export default Router

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
+const {run} = Ember
 
 export default function destroyApp (application) {
-  Ember.run(application, 'destroy')
+  run(application, 'destroy')
 }

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,5 +1,5 @@
-import Resolver from '../../resolver'
 import config from '../../config/environment'
+import Resolver from '../../resolver'
 
 const resolver = Resolver.create()
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,14 +1,19 @@
-import Ember from 'ember'
+/* eslint-disable ember-standard/destructure */
+
 import Application from '../../app'
 import config from '../../config/environment'
+import Ember from 'ember'
+const {run} = Ember
+
+const assign = Object.assign || Ember.assign || Ember.merge
 
 export default function startApp (attrs) {
   let application
 
-  let attributes = Ember.merge({}, config.APP)
-  attributes = Ember.merge(attributes, attrs) // use defaults, but you can override;
+  let attributes = assign({}, config.APP)
+  attributes = assign(attributes, attrs) // use defaults, but you can override
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()

--- a/tests/integration/components/frost-file-picker-test.js
+++ b/tests/integration/components/frost-file-picker-test.js
@@ -1,12 +1,12 @@
 /* global capture, Blob */
+import {assert, expect} from 'chai'
 import Ember from 'ember'
 const {$} = Ember
-import {expect, assert} from 'chai'
+import {$hook, initialize as initializeHook} from 'ember-hook'
 import {setupComponentTest} from 'ember-mocha'
 import hbs from 'htmlbars-inline-precompile'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
-import {$hook, initialize as initializeHook} from 'ember-hook'
 
 /**
  * Create a new file with the given content and options

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,4 @@
 import resolver from './helpers/resolver'
-import { setResolver } from 'ember-mocha'
+import {setResolver} from 'ember-mocha'
 
 setResolver(resolver)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-file-picker/issues/39

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.
