### PR TITLE
Added blueprint check + missing spread dependency

### DIFF
--- a/blueprints/ember-frost-file-picker/index.js
+++ b/blueprints/ember-frost-file-picker/index.js
@@ -1,19 +1,30 @@
-module.exports = {
-  description: '',
-  normalizeEntityName: function () {},
+const blueprintHelper = require('ember-frost-core/blueprint-helper')
 
-  /**
-    Installs specified packages at the root level of the application.
-    Triggered by 'ember install <addon name>'.
-    @returns {Promise} package names and versions
-  */
-  afterInstall: function () {
-    return this.addAddonsToProject({
-      packages: [
-        {name: 'ember-frost-core', target: '^1.0.0'},
-        {name: 'ember-prop-types', target: '^3.0.0'},
-        {name: 'ember-hook', target: '^1.3.1'}
-      ]
+module.exports = {
+  afterInstall: function (options) {
+    const addonsToAdd = [
+      {name: 'ember-frost-core', target: '^1.14.3'},
+      {name: 'ember-prop-types', target: '^3.0.0'},
+      {name: 'ember-hook', target: '^1.3.1'}
+    ]
+
+    // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within
+    // the required semver range will not be re-installed or have blueprints re-run.
+    const consumerPackages = blueprintHelper.consumer.getPackages(options)
+
+    // Get the packages to install (not already installed) from a list of potential packages
+    return blueprintHelper.packageHandler.getPkgsToInstall(addonsToAdd, consumerPackages).then((pkgsToInstall) => {
+      if (pkgsToInstall.length !== 0) {
+        // Call the blueprint hook
+        return this.addAddonsToProject({
+          packages: pkgsToInstall
+        })
+      }
     })
+  },
+
+  normalizeEntityName: function () {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter to us)
   }
 }

--- a/blueprints/ember-frost-file-picker/index.js
+++ b/blueprints/ember-frost-file-picker/index.js
@@ -3,9 +3,7 @@ const blueprintHelper = require('ember-frost-core/blueprint-helper')
 module.exports = {
   afterInstall: function (options) {
     const addonsToAdd = [
-      {name: 'ember-frost-core', target: '^1.14.3'},
-      {name: 'ember-prop-types', target: '^3.0.0'},
-      {name: 'ember-hook', target: '^1.3.1'}
+      {name: 'ember-frost-core', target: '^1.14.3'}
     ]
 
     // Get the packages installed in the consumer app/addon. Packages that are already installed in the consumer within

--- a/package.json
+++ b/package.json
@@ -49,13 +49,13 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-elsewhere": "~0.4.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-frost-core": "^1.0.0",
     "ember-hook": "^1.3.5",
     "ember-load-initializers": "^0.5.0",
     "ember-lodash": "~0.0.7",
-    "ember-prop-types": "~3.0.0",
+    "ember-prop-types": "3.11.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.5.1",
+    "ember-spread": "1.1.4",
     "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.2.0",
     "loader.js": "^4.0.0"
@@ -68,6 +68,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
+    "ember-frost-core": "^1.14.3",
     "ember-prop-types": "^3.0.0",
     "liquid-fire": "~0.26.0"
   },

--- a/package.json
+++ b/package.json
@@ -68,9 +68,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-sass": "^5.2.0",
-    "ember-frost-core": "^1.14.3",
-    "ember-prop-types": "^3.0.0",
-    "liquid-fire": "~0.26.0"
+    "ember-frost-core": "^1.14.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Added** blueprint check
* **Added** missing dependency to `ember-spread`