### PR TITLE
Default to accepting all files, fix proptypes

### DIFF
--- a/addon/components/frost-file-picker.js
+++ b/addon/components/frost-file-picker.js
@@ -13,7 +13,7 @@ export default Component.extend(PropTypeMixin, {
 
   // == State Properties ======================================================
   propTypes: {
-    accept: PropTypes.string.required,
+    accept: PropTypes.string,
     hook: PropTypes.string,
     placeholderText: PropTypes.string
   },

--- a/package.json
+++ b/package.json
@@ -19,13 +19,19 @@
   },
   "author": "Eric White (https://github.com/EWhite613)",
   "contributors": [
-    "Quincy Le (https://github.com/quincyle)",
+    "Jeremy Brown (https://github.com/notmessenger)",
+    "Michael Carroll (https://github.com/juwara0)",
+    "David Fortin (https://github.com/dafortin)",
     "Gosia Hyndman (https://github.com/vesper2000)",
-    "Seena Rowhani (https://github.com/srowhani)",
-    "Roxanne Panthaky (https://github.com/rox163)"
+    "Gabriel Knoy (https://github.com/gknoy)",
+    "Quincy Le (https://github.com/quincyle)",
+    "Roxanne Panthaky (https://github.com/rox163)",
+    "Phillip Plummer (https://github.com/TheOtherDude)",
+    "Seena Rowhani (https://github.com/srowhani)"
   ],
   "license": "MIT",
   "devDependencies": {
+    "bower": "^1.8.0",
     "broccoli-asset-rev": "^2.4.5",
     "ember-browserify": "~1.1.9",
     "ember-cli": "2.12.3",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -40,6 +40,13 @@ module.exports = function (environment) {
     ENV.APP.LOG_ACTIVE_GENERATION = false
     ENV.APP.LOG_VIEW_LOOKUPS = false
 
+    ENV['ember-prop-types'] = {
+      requireComponentPropTypes: true,
+      throwErrors: true,  // Throw errors instead of logging warnings (default is false)
+      validate: true,
+      validateOnUpdate: true  // Validate properties when they are updated (default is false)
+    }
+
     ENV.APP.rootElement = '#ember-testing'
   }
 

--- a/tests/integration/components/frost-file-picker-test.js
+++ b/tests/integration/components/frost-file-picker-test.js
@@ -65,6 +65,10 @@ describe('Integration/ Component / frost-file-picker', function () {
       expect($hook('my-picker')).to.have.length(1)
     })
 
+    it('should accept all files', function () {
+      expect($('input').attr('accept')).to.equal('*')
+    })
+
     describe('when uploading a file', function () {
       beforeEach(function () {
         $('input').on('change', function (e) {
@@ -96,6 +100,20 @@ describe('Integration/ Component / frost-file-picker', function () {
 
     it('should use the provided placeholder text', function () {
       expect($hook('my-picker-input').attr('placeholder')).to.eql('Custom placeholder')
+    })
+  })
+
+  describe('when accept is given', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-file-picker
+          accept='png'
+        }}
+      `)
+    })
+
+    it('should accept that file extension', function () {
+      expect($('input').attr('accept')).to.equal('png')
     })
   })
 

--- a/tests/unit/frost-file-picker-test.js
+++ b/tests/unit/frost-file-picker-test.js
@@ -1,0 +1,21 @@
+import {expect} from 'chai'
+import {setupComponentTest} from 'ember-mocha'
+import {helpers} from 'ember-prop-types'
+import {beforeEach, describe, it} from 'mocha'
+const {validatePropTypes} = helpers
+
+describe('Unit / Component / frost-file-picker /', function () {
+  setupComponentTest('frost-file-picker', {unit: true})
+
+  let component
+  beforeEach(function () {
+    component = this.subject({accept: '*'})
+  })
+
+  describe('`proptypes` validation', function () {
+    it('should have valid `proptypes` declaration', function () {
+      validatePropTypes(component)  // raises an exception if it fails
+      expect(true).to.equal(true)
+    })
+  })
+})

--- a/tests/unit/frost-file-picker-test.js
+++ b/tests/unit/frost-file-picker-test.js
@@ -1,7 +1,10 @@
 import {expect} from 'chai'
 import {setupComponentTest} from 'ember-mocha'
-import {helpers} from 'ember-prop-types'
-import {beforeEach, describe, it} from 'mocha'
+import {
+  helpers,
+  settings as propTypesSettings
+} from 'ember-prop-types/mixins/prop-types'
+import {afterEach, beforeEach, describe, it} from 'mocha'
 const {validatePropTypes} = helpers
 
 describe('Unit / Component / frost-file-picker /', function () {
@@ -13,10 +16,23 @@ describe('Unit / Component / frost-file-picker /', function () {
   })
 
   describe('`proptypes` validation', function () {
+    let throwErrors
+
+    beforeEach(function () {
+      // save our real settings so that we can force validation,
+      // in case our environment.js ever decides that such validation should be optional.
+      throwErrors = propTypesSettings.throwErrors
+      propTypesSettings.throwErrors = true
+    })
+
+    afterEach(function () {
+      propTypesSettings.throwErrors = throwErrors
+    })
+
     it('should have valid `proptypes` declaration', function () {
       expect(function () {
         validatePropTypes(component)
-      }).not.to.throw()
+      }).to.not.throw()
     })
   })
 })

--- a/tests/unit/frost-file-picker-test.js
+++ b/tests/unit/frost-file-picker-test.js
@@ -14,8 +14,9 @@ describe('Unit / Component / frost-file-picker /', function () {
 
   describe('`proptypes` validation', function () {
     it('should have valid `proptypes` declaration', function () {
-      validatePropTypes(component)  // raises an exception if it fails
-      expect(true).to.equal(true)
+      expect(function () {
+        validatePropTypes(component)
+      }).not.to.throw()
     })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This PR makes the `accept` property optional (default `'*'`).

When strict proptype checking is enabled, the `accept` field used to
fail with an error which said _"Unknown proptype undefined"_, because
its proptype declaration was incorrect.

# CHANGELOG
- The `accept` property (default '*') is no longer required
- Fixed the specification of the file picker's proptypes
- Added tests that validate `proptypes` of our component
